### PR TITLE
_resolveID barfs if it finds a relic watchedvariables entry that has …

### DIFF
--- a/IDE Bundle/Contents/Tools/Toolset/libraries/revdebuggerlibrary.livecodescript
+++ b/IDE Bundle/Contents/Tools/Toolset/libraries/revdebuggerlibrary.livecodescript
@@ -1948,6 +1948,8 @@ end __ActivateBreakpoints
 #   being resolved is in the stack script.
 private function __ResolveId pId, pStack
    local tID
+	# [[2023.06.06 MDW fix_resolve_crash_in_debugger]]
+	try
    if pId is 0 then
       put the long id of pStack into tID
    else
@@ -1958,6 +1960,8 @@ private function __ResolveId pId, pStack
          put the long id of control id pId of pStack into tID
       end if
    end if
+	catch e
+	end try
    return tID
 end __ResolveId
 


### PR DESCRIPTION
…a no-longer-existent object reference

This can have disastrous consequences, the least of which would be a non-firing preOpenStack handler.