### PR TITLE
fixes LC bug 16880 by setting the minHeight of the menubar

### DIFF
--- a/IDE Bundle/Contents/Tools/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/IDE Bundle/Contents/Tools/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -251,6 +251,8 @@ on setMenuProperties
    local tScreenRect
    put revIDEStackScreenRect(the short name of this stack, true) into tScreenRect
 
+	# 2023.06.06 MDW [[bugfix_16880]]
+	set the minHeight of me to 19
    if the platform is not "MacOS" then
       if item 3 of the screenRect is 800 then
          set the topLeft of me to item 1 to 2 of tScreenRect


### PR DESCRIPTION
Probably only affects the glx2 script editor at this point, but the minHeight of the menubar is set too high, so disabling both the display of icons *and* text causes weird crashing.