### PR TITLE
Don't make invisible windows visible on linux

### DIFF
--- a/IDE Bundle/Contents/Tools/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/IDE Bundle/Contents/Tools/Toolset/libraries/revidelibrary.8.livecodescript
@@ -10030,10 +10030,10 @@ on revIDESendCurrentWindowToBack
    then put tWindows2 & return & tWindows into tWindows
 
    repeat for each line l in tWindows
-      -- delete char 1 to 2 of l
-      if the mode of stack l is 1 or the mode of stack l is 2 then toplevel l
-      else if the mode of stack l is 3 then modeless l
-      show stack l
+		if the visible of stack l then
+			if the mode of stack l is 1 or the mode of stack l is 2 then toplevel l
+			else if the mode of stack l is 3 then modeless l
+		end if
    end repeat
    unlock messages
 end revIDESendCurrentWindowToBack


### PR DESCRIPTION
I find I often hit command-quote instead of shift-quote on the keyboard, which has the effect from the menubar of sending the current stack to the back. On linux this also makes any invisible stacks (I have three invisible plugin stacks hiding in the background) visible and forces me to close each one to restore my desktop. Don't know what happens on Windows, but on OSX this isn't a problem. At any rate, this patch fixes the problem by simply ignoring stacks with their visible set to false.