### PR TITLE
Place newly created stacks at center of screen

### DIFF
--- a/IDE Bundle/Contents/Tools/Toolset/palettes/menubar/revmenubar.livecodescript
+++ b/IDE Bundle/Contents/Tools/Toolset/palettes/menubar/revmenubar.livecodescript
@@ -2791,6 +2791,10 @@ on revMenubarFileMenuPick pWhich
                else
                   revIDEOpenStack tRecentStack
                end if
+				# 2023.06.06 MDW [[center new stacks on linux]]
+				local tStack
+				put the result into tStack
+				set the location of tStack to the screenloc
                break
             case "Import As Control"
                put item 2 of pWhich into tType


### PR DESCRIPTION
Currently new stack creation places the stack in the upper left corner of the screen.
This patch places it at the center of the screen instead.