### PR TITLE
Allow "passed" dispatch commands in menu revHooks

### DIFF
--- a/IDE Bundle/Contents/Tools/Toolset/palettes/script editor/behaviors/revsemenubarbehavior.livecodescript
+++ b/IDE Bundle/Contents/Tools/Toolset/palettes/script editor/behaviors/revsemenubarbehavior.livecodescript
@@ -611,7 +611,8 @@ private function modifyMenu pMenuName, pMenu
    
    local tModifiedMenu
    dispatch "revHookBuildScriptEditorMenu" to me with pMenuName, pMenu, tModifiedMenu
-   if it is not "handled" then
+		# 2023.06.06 MDW allow_passed_commands
+	if it is "unhandled" then
       put pMenu into tModifiedMenu
    end if
    return tModifiedMenu


### PR DESCRIPTION
Dispatch commands can return one of three states in the "it" variable:
handled, unhandled, and passed
This patch allows a return state of "passed" as well as "handled" to allow for chained revHook... handlers.