### PR TITLE
newly created objects should get unique names

### DIFF
--- a/IDE Bundle/Contents/Tools/Toolset/libraries/revidelibrary.8.livecodescript
+++ b/IDE Bundle/Contents/Tools/Toolset/libraries/revidelibrary.8.livecodescript
@@ -3370,6 +3370,16 @@ on revIDECreateObject pObjectTypeID, pTarget, pLoc
 
    __setPropertiesToDefaults tCreatedControlID, tObjPropsA
 
+	# 2023.06.06 MDW newly created objects should get unique names
+	if pObjectTypeID begins with "com.livecode.interface.classic.DataGrid" then
+	else
+		put 1 into tCount
+		repeat while there is a control (tObjectType & tCount)
+			add 1 to tCount
+		end repeat
+		set the name of tCreatedControlID to (tObjectType & tCount)
+	end if
+
    ## Set the size of the object to the size set in the Preferences
    __setSizeToPreference tCreatedControlID, pObjectTypeID
 


### PR DESCRIPTION
Newly created datagrids already get unique names. Other objects get names based on their object types from a property array. This patch follows the array assignment and gives a unique name to the new object.